### PR TITLE
Object serialization test trips Intel compiler

### DIFF
--- a/tests/mpi/eckit_test_mpi_objserialisation.cc
+++ b/tests/mpi/eckit_test_mpi_objserialisation.cc
@@ -219,12 +219,12 @@ public:
 
         eckit::ResizableMemoryStream s(b);
 
-        Obj o(s);
+        //Obj o(s);
 
-        eckit::Log::info() << "[" << me_ << "] "
-                           << "receiving from " << from << " --- " << o << std::endl;
+        //eckit::Log::info() << "[" << me_ << "] "
+        //                   << "receiving from " << from << " --- " << o << std::endl;
 
-        return o;
+        return Obj(s);
     }
 };
 


### PR DESCRIPTION
Class ```Obj``` (defined in line 63 of the file) is not copiable. 

Intel 18 (on Hera, in C++14 mode) complains about this. I assume that we didn't encounter this error before because the compiler was performing return value optimization.
